### PR TITLE
Fixes Python dependency failures on Raspberry Pi OS Bookworm

### DIFF
--- a/debian-pkg/debian/tinypilot.service
+++ b/debian-pkg/debian/tinypilot.service
@@ -10,6 +10,7 @@ User=tinypilot
 WorkingDirectory=/opt/tinypilot
 ExecStart=/opt/tinypilot/venv/bin/python app/main.py
 Environment=APP_SETTINGS_FILE=/home/tinypilot/app_settings.cfg
+Environment=PATH=/opt/tinypilot/venv/bin
 Restart=always
 
 [Install]


### PR DESCRIPTION
Python needs path to be specified in the service environment in Bookworm so it can load the modules included with the service